### PR TITLE
Travis ci pagination

### DIFF
--- a/ci_plugins.yml
+++ b/ci_plugins.yml
@@ -1,2 +1,2 @@
 plugins: 
-  - {name: "travis-ci", interface: "cli", repo: "http://github.com/crosscloudci/ci_plugin_travis_go", ref: "v0.0.4"}
+  - {name: "travis-ci", interface: "cli", repo: "http://github.com/crosscloudci/ci_plugin_travis_go", ref: "v0.0.5"}

--- a/test/controllers/page_controller_test.exs
+++ b/test/controllers/page_controller_test.exs
@@ -6,6 +6,7 @@ defmodule ExCiProxy.PageControllerTest do
   @ci_system_misconfigured %{project: "prometheus", ref: "834f6f81e394", arch: "amd64", interface: "cli"  }
   @missing_commit %{project: "testproj", ref: "fjdkafdjkaljdfkla", arch: "amd64", interface: "cli"  }
   @failed_commit %{project: "testproj", ref: "afb4d68b0f9", arch: "amd64", interface: "cli"  }
+  @linkerd2 %{project: "linkerd2", ref: "368d16f23", arch: "amd64", interface: "cli"  }
 
   test "lists all entries on index", %{conn: conn} do
     ExCiProxy.RegisterPlugin.register_all_ci_system_dependencies()
@@ -13,6 +14,16 @@ defmodule ExCiProxy.PageControllerTest do
     conn = get conn, page_path(conn, :index), @valid_attrs
     _page = json_response(conn, 200)
     assert  %{ "build_url" => "https://travis-ci.org/crosscloudci/testproj/builds/569941325 ",
+                    "status" => "success"
+      } = json_response(conn, 200)["build_status"]
+  end
+
+  test "linkerd2 should pass", %{conn: conn} do
+    ExCiProxy.RegisterPlugin.register_all_ci_system_dependencies()
+    ExCiProxy.RegisterPlugin.register_all_ci_systems()
+    conn = get conn, page_path(conn, :index), @linkerd2
+    _page = json_response(conn, 200)
+    assert  %{ "build_url" => "https://travis-ci.org/linkerd/linkerd2/builds/578036893 ",
                     "status" => "success"
       } = json_response(conn, 200)["build_status"]
   end


### PR DESCRIPTION
Issue Name: travis ci pagination

## Short Description:
Support searching Travis CI build history

## Description

To update Travis CI integration to search for build jobs that are further back in the Travis history than the first set of returned results
For example, Stable-2.5.0 is over 100 jobs after the current commit

## Which issue(s) this PR fixes: Public / Internal
crosscloudci/crosscloudci/issues/189

## Motivation and Context:

## How Has This Been Tested?

- [] Covered by existing integration testing
- [] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] Covered by existing documentation.

###
Travis sorting now working for f6e8d3a7ae3b56d595d014a846a1f
![image](https://user-images.githubusercontent.com/29548/64279511-d157d280-cf14-11e9-89b0-c3b3ccf1b726.png)
