### PR TITLE
Travis ci pagination

### DIFF
--- a/web/router.ex
+++ b/web/router.ex
@@ -15,7 +15,7 @@ defmodule ExCiProxy.Router do
 
   scope "/", ExCiProxy do
     pipe_through [:api]
-    resources "/ci_status_build/commit_ref", PageController, except: [:new, :edit]
+    resources "/ciproxy/v1/ci_status_build/commit_ref", PageController, except: [:new, :edit]
     # get "/", PageController, :index
   end
 


### PR DESCRIPTION
Issue Name: travis ci pagination

## Short Description:
Support searching Travis CI build history

## Description

To update Travis CI integration to search for build jobs that are further back in the Travis history than the first set of returned results
For example, Stable-2.5.0 is over 100 jobs after the current commit

## Which issue(s) this PR fixes: Public / Internal
- crosscloudci/crosscloudci/issues/189
- crosscloudci/crosscloudci/issues/192

## Motivation and Context:

## How Has This Been Tested?

- [] Covered by existing integration testing
- [] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] Covered by existing documentation.

###
