### PR TITLE
travis.com changes

### DIFF
--- a/ci_plugins.yml
+++ b/ci_plugins.yml
@@ -1,4 +1,4 @@
 plugins: 
   - {name: "travis-ci", interface: "cli", repo: "http://github.com/crosscloudci/ci_plugin_travis_go", ref: "v0.0.7"}
   - {name: "github-actions", interface: "cli", repo: "http://github.com/crosscloudci/cr_plugin_github_actions", ref: "v0.0.8"}
-  - {name: "travis-ci-com", interface: "cli", repo: "http://github.com/crosscloudci/ci_plugin_travis_com_go", ref: "v0.0.2"}
+  - {name: "travis-ci-com", interface: "cli", repo: "http://github.com/crosscloudci/ci_plugin_travis_com_go", ref: "v0.0.3"}


### PR DESCRIPTION
## Description
1.  switches to new version of travis plugin that displays travis.com as the url in the job

Issues:
- crosscloudci/crosscloudci#209

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [x] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Browser tested on staging.cncf.ci
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* []  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.